### PR TITLE
Modify path for files used with samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note: The sample scripts require [**Image Processing Toolbox**](https://se.mathw
 1. [**Install Zivid Software**](https://www.zivid.com/downloads).
 Note: The version tested with Zivid cameras is 1.8.0.
 
-3. [**Download Zivid Sample Data**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/edit-v2/450363393?draftShareId=2fd72323-1c01-4acb-8016-ed74206c4edb).
+3. [**Download Zivid Sample Data**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/450363393/Sample+Data).
 
 4. [**Install MATLAB Software**](https://se.mathworks.com/products/matlab.html).
 Note: The version tested with Zivid cameras is 2019a.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ Note: The sample scripts require [**Image Processing Toolbox**](https://se.mathw
 1. [**Install Zivid Software**](https://www.zivid.com/downloads).
 Note: The version tested with Zivid cameras is 1.8.0.
 
-2. [**Install MATLAB Software**](https://se.mathworks.com/products/matlab.html).
+3. [**Download Zivid Sample Data**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/edit-v2/450363393?draftShareId=2fd72323-1c01-4acb-8016-ed74206c4edb).
+
+4. [**Install MATLAB Software**](https://se.mathworks.com/products/matlab.html).
 Note: The version tested with Zivid cameras is 2019a.
 
-3. Launch MATLAB.
+5. Launch MATLAB.
 
-4. Open and run one of the samples.
+6. Open and run one of the samples.
 
 ## Support
 If you need assistance with using Zivid cameras, visit our Knowledge Base at [https://help.zivid.com/](https://help.zivid.com/) or contact us at [customersuccess@zivid.com](mailto:customersuccess@zivid.com).

--- a/source/Applications/Advanced/Downsample.m
+++ b/source/Applications/Advanced/Downsample.m
@@ -1,7 +1,7 @@
 % Import ZDF point cloud and downsample it.
 
 % The "Zivid3D.zdf" file has to be in the same folder as the "ReadZDF" file.
-Filename = 'Zivid3D.zdf';
+Filename = strcat(char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf');
 
 % Adding directory that contains zdfread to search path.
 addpath(genpath([fileparts(pwd), filesep, 'Basic']));

--- a/source/Applications/Advanced/Downsample.m
+++ b/source/Applications/Advanced/Downsample.m
@@ -1,10 +1,13 @@
 % Import ZDF point cloud and downsample it.
 
+% Adding directories that contains zividApplication and zdfread to search path.
+addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
+addpath(genpath([fileparts(fileparts(mfilename('fullpath'))), filesep, 'Basic', filesep, 'FileFormats']));
+
+app = zividApplication;
+
 % The "Zivid3D.zdf" file has to be in the same folder as the "ReadZDF" file.
 Filename = [char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf'];
-
-% Adding directory that contains zdfread to search path.
-addpath(genpath([fileparts(pwd), filesep, 'Basic']));
 
 % Reading a .ZDF point cloud.
 [X,Y,Z,R,G,B,Image,Contrast] = zdfread(Filename);

--- a/source/Applications/Advanced/Downsample.m
+++ b/source/Applications/Advanced/Downsample.m
@@ -1,7 +1,7 @@
 % Import ZDF point cloud and downsample it.
 
 % The "Zivid3D.zdf" file has to be in the same folder as the "ReadZDF" file.
-Filename = strcat(char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf');
+Filename = [char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf'];
 
 % Adding directory that contains zdfread to search path.
 addpath(genpath([fileparts(pwd), filesep, 'Basic']));

--- a/source/Applications/Basic/FileFormats/ReadIterateZDF.m
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF.m
@@ -1,7 +1,12 @@
 % Import ZDF point cloud.
 
+% Adding directory that contains zividApplication to search path.
+addpath(genpath([fileparts(fileparts(fileparts(pwd))),filesep,'Camera',filesep,'Basic']));
+
+app = zividApplication;
+
 % The Zivid3D.zdf file has to be in the same folder as this sample script.
-Filename = 'Zivid3D.zdf';
+Filename = strcat(char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf');
 
 % Reading a .ZDF point cloud.
 [X,Y,Z,R,G,B,Image,Contrast] = zdfread(Filename);

--- a/source/Applications/Basic/FileFormats/ReadIterateZDF.m
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF.m
@@ -1,7 +1,7 @@
 % Import ZDF point cloud.
 
 % Adding directory that contains zividApplication to search path.
-addpath(genpath([fileparts(fileparts(fileparts(pwd))),filesep,'Camera',filesep,'Basic']));
+addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
 
 app = zividApplication;
 

--- a/source/Applications/Basic/FileFormats/ReadIterateZDF.m
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF.m
@@ -1,7 +1,7 @@
 % Import ZDF point cloud.
 
 % Adding directory that contains zividApplication to search path.
-addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
+addpath(genpath([fileparts(fileparts(fileparts(fileparts(mfilename('fullpath'))))),filesep,'Camera',filesep,'Basic']));
 
 app = zividApplication;
 

--- a/source/Applications/Basic/FileFormats/ReadIterateZDF.m
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF.m
@@ -6,7 +6,7 @@ addpath(genpath([fileparts(fileparts(fileparts(pwd))),filesep,'Camera',filesep,'
 app = zividApplication;
 
 % The Zivid3D.zdf file has to be in the same folder as this sample script.
-Filename = strcat(char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf');
+Filename = [char(Zivid.NET.Environment.DataPath), '/Zivid3D.zdf'];
 
 % Reading a .ZDF point cloud.
 [X,Y,Z,R,G,B,Image,Contrast] = zdfread(Filename);

--- a/source/Applications/Basic/FileFormats/zdfread.m
+++ b/source/Applications/Basic/FileFormats/zdfread.m
@@ -20,7 +20,7 @@ function [X, Y, Z, R, G, B, Image, Contrast] = zdfread(Filename)
 try
     if strcmp(Filename(end-3:end),'.zdf')
         
-        disp(['Reading ',sprintf('%s',Filename),' point cloud'])
+        disp(['Reading point cloud: ',sprintf('%s',Filename)])
         
         % Reading the color image from rgba_image
         % and spliting in R, G, B normalized matrices.

--- a/source/Applications/Basic/FileFormats/zdfread.m
+++ b/source/Applications/Basic/FileFormats/zdfread.m
@@ -20,7 +20,7 @@ function [X, Y, Z, R, G, B, Image, Contrast] = zdfread(Filename)
 try
     if strcmp(Filename(end-3:end),'.zdf')
         
-        disp(['Reading point cloud: ',sprintf('%s',Filename)])
+        disp(['Reading point cloud: ',Filename])
         
         % Reading the color image from rgba_image
         % and spliting in R, G, B normalized matrices.

--- a/source/Applications/Basic/Visualization/CaptureFromFileVis3D.m
+++ b/source/Applications/Basic/Visualization/CaptureFromFileVis3D.m
@@ -1,6 +1,6 @@
 try
     % Adding directory that contains zividApplication to search path.
-    addpath(genpath([fileparts(fileparts(fileparts(pwd))),filesep,'Camera',filesep,'Basic']));
+    addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
 
     app = zividApplication;
 

--- a/source/Applications/Basic/Visualization/CaptureFromFileVis3D.m
+++ b/source/Applications/Basic/Visualization/CaptureFromFileVis3D.m
@@ -1,6 +1,6 @@
 try
     % Adding directory that contains zividApplication to search path.
-    addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
+    addpath(genpath([fileparts(fileparts(fileparts(fileparts(mfilename('fullpath'))))),filesep,'Camera',filesep,'Basic']));
 
     app = zividApplication;
 

--- a/source/Applications/Basic/Visualization/CaptureVis3D.m
+++ b/source/Applications/Basic/Visualization/CaptureVis3D.m
@@ -1,6 +1,6 @@
 try
     % Adding directory that contains zividApplication to search path.
-    addpath(genpath([fileparts(fileparts(fileparts(pwd))),filesep,'Camera',filesep,'Basic']));
+    addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
 
     app = zividApplication;
 

--- a/source/Applications/Basic/Visualization/CaptureVis3D.m
+++ b/source/Applications/Basic/Visualization/CaptureVis3D.m
@@ -1,6 +1,6 @@
 try
     % Adding directory that contains zividApplication to search path.
-    addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
+    addpath(genpath([fileparts(fileparts(fileparts(fileparts(mfilename('fullpath'))))),filesep,'Camera',filesep,'Basic']));
 
     app = zividApplication;
 

--- a/source/Camera/Basic/Capture.m
+++ b/source/Camera/Basic/Capture.m
@@ -15,7 +15,7 @@ try
     disp('Capturing a frame');
     frame = camera.Capture;
 
-    resultFile = 'result.zdf';
+    resultFile = 'Result.zdf';
     disp(['Saving frame to file: ' resultFile]);
     frame.Save(resultFile);
 

--- a/source/Camera/Basic/Capture2D.m
+++ b/source/Camera/Basic/Capture2D.m
@@ -22,7 +22,7 @@ try
     byteArray = uint8(image2D.ToArray);
     disp(['First four bytes:  [1]: ',num2str(byteArray(1)),', [2]: ',num2str(byteArray(2)),', [3]: ',num2str(byteArray(3)),', [4]: ',num2str(byteArray(4))]);
 
-    resultFile = 'image.png';
+    resultFile = 'Image.png';
     disp(['Saving image to file: ' resultFile]);
     image2D.Save(resultFile);
 

--- a/source/Camera/Basic/CaptureAssistant.m
+++ b/source/Camera/Basic/CaptureAssistant.m
@@ -16,7 +16,7 @@ try
     disp('Capturing (and merge) frames using automatically suggested settings');
     hdrFrame = Zivid.NET.HDR.Capture(camera, settingsList);
 
-    resultFile = 'result.zdf';
+    resultFile = 'Result.zdf';
     disp(['Saving frame to file: ' resultFile]);
     hdrFrame.Save(resultFile);
 

--- a/source/Camera/Basic/CaptureFromFile.m
+++ b/source/Camera/Basic/CaptureFromFile.m
@@ -1,7 +1,7 @@
 try
     app = zividApplication;
 
-    zdfFile = strcat(char(Zivid.NET.Environment.DataPath), '/MiscObjects.zdf');    
+    zdfFile = [char(Zivid.NET.Environment.DataPath), '/MiscObjects.zdf'];
     disp(['Initializing camera emulation using file: ', zdfFile]);
     camera = app.CreateFileCamera(zdfFile);
 

--- a/source/Camera/Basic/CaptureFromFile.m
+++ b/source/Camera/Basic/CaptureFromFile.m
@@ -8,7 +8,7 @@ try
     disp('Capturing a frame');
     frame = camera.Capture();
 
-    resultFile = 'result.zdf';
+    resultFile = 'Result.zdf';
     disp(['Saving frame to file: ', resultFile]);
     frame.Save(resultFile);
 

--- a/source/Camera/Basic/CaptureTutorial.md
+++ b/source/Camera/Basic/CaptureTutorial.md
@@ -163,7 +163,7 @@ settings2D.Brightness = 1.0
 
 Zivid Studio can store the current settings to .yml files. These can be read and applied in the API. You may find it easier to modify the settings in these (human-readable) yaml-files in your preferred editor.
 ```Matlab
-camera.SetSettings(Zivid.NET.Settings("frame_01.yml"));
+camera.SetSettings(Zivid.NET.Settings("Frame01.yml"));
 ```
 
 ## Capture
@@ -193,7 +193,7 @@ image2D = NET.invokeGenericMethod(frame2D,'Image',{'Zivid.NET.RGBA8'})
 
 We can now save our results ([go to source][save-url]).
 ```Matlab
-frame.Save('result.zdf');
+frame.Save('Result.zdf');
 ```
 The API detects which format to use. See [Point Cloud][kb-point_cloud-url] for a list of supported formats.
 
@@ -201,7 +201,7 @@ The API detects which format to use. See [Point Cloud][kb-point_cloud-url] for a
 
 If we captured a 2D image, we can save it ([go to source][save2d-url]).
 ```Matlab
-image2D.Save('result.png');
+image2D.Save('Result.png');
 ```
 
 ## Disconnect

--- a/source/Camera/Basic/QuickCaptureTutorial.md
+++ b/source/Camera/Basic/QuickCaptureTutorial.md
@@ -33,7 +33,7 @@ frame = camera.Capture;
 
 We can now save our results. By default the 3D point cloud is saved in Zivid format `.zdf` ([go to source][save-url]).
 ```Matlab
-frame.Save("result.zdf");
+frame.Save("Result.zdf");
 ```
 
 ## Disconnect

--- a/source/Camera/InfoUtilOther/GetCameraIntrinsics.m
+++ b/source/Camera/InfoUtilOther/GetCameraIntrinsics.m
@@ -2,7 +2,7 @@
 
 try
     % Adding directory that contains zividApplication to search path.
-    addpath(genpath([fileparts(fileparts(pwd)),filesep,'Camera',filesep,'Basic']));
+    addpath(genpath([fileparts(fileparts(mfilename('fullpath'))),filesep,'Camera',filesep,'Basic']));
 
     app = zividApplication;
 

--- a/source/Camera/InfoUtilOther/GetCameraIntrinsics.m
+++ b/source/Camera/InfoUtilOther/GetCameraIntrinsics.m
@@ -9,7 +9,7 @@ try
     disp('Connecting to camera')
     camera = app.ConnectCamera;
 
-    fileNameIntrinsics = 'intrinsics.yml';
+    fileNameIntrinsics = 'Intrinsics.yml';
     disp(['Saving camera intrinsics to file: ', fileNameIntrinsics]);
     camera.Intrinsics.save(fileNameIntrinsics);
 

--- a/source/Camera/InfoUtilOther/GetCameraIntrinsics.m
+++ b/source/Camera/InfoUtilOther/GetCameraIntrinsics.m
@@ -2,7 +2,7 @@
 
 try
     % Adding directory that contains zividApplication to search path.
-    addpath(genpath([fileparts(fileparts(mfilename('fullpath'))),filesep,'Camera',filesep,'Basic']));
+    addpath(genpath([fileparts(fileparts(fileparts(mfilename('fullpath')))),filesep,'Camera',filesep,'Basic']));
 
     app = zividApplication;
 


### PR DESCRIPTION
This commit assumes that all the files that are loaded by zivid samples are located at ZIVID_DATA path variable.